### PR TITLE
Update NOKOlino.ino - Ersatzen von eincodierter Konstante durch definierte Konstante

### DIFF
--- a/src/NOKOlino/NOKOlino.ino
+++ b/src/NOKOlino/NOKOlino.ino
@@ -128,7 +128,7 @@ while(1)
   if (!low) 
   {
     if (!(PINB & (1<<PB2))) JQ6500_play(random(0,Button_event+1));      // Button event
-    else if (random(0,Time*60*8)==1) JQ6500_play(random(21,Time_event+1)); // Time event
+    else if (random(0,Time*60*8)==1) JQ6500_play(random(Button_event+1,Time_event+1)); // Time event
     else attiny_sleep();
   }
   


### PR DESCRIPTION
Hier sollte die eincodierte Konstante `21` durch die definierte Konstante `Button_event+1` ersetzt werden, da sonst Probleme auftreten, wenn jemand neue Sprachdateien benutzen möchte und nicht genau 20 Tasten-Dateien benutzt.